### PR TITLE
Fix Dialog Title Label typo

### DIFF
--- a/Source/Depressurizer/Dialogs/DepressurizerDialog.cs
+++ b/Source/Depressurizer/Dialogs/DepressurizerDialog.cs
@@ -36,7 +36,7 @@ namespace Depressurizer.Dialogs
 		{
 			InitializeComponent();
 
-			TitleLabel.Text = string.Format(CultureInfo.InvariantCulture, "Depressurzier - {0}", dialogTitle);
+			TitleLabel.Text = string.Format(CultureInfo.InvariantCulture, "Depressurizer - {0}", dialogTitle);
 		}
 
 		#endregion


### PR DESCRIPTION
The Title said "Depressurzier" where it should say "Depressurizer". It' s a minor typo fix with no other changes